### PR TITLE
sys/src/cmd/cpp: add #include_next directive

### DIFF
--- a/sys/src/cmd/cpp/cpp.c
+++ b/sys/src/cmd/cpp/cpp.c
@@ -239,7 +239,12 @@ control(Tokenrow *trp)
 		break;
 
 	case KINCLUDE:
-		doinclude(trp);
+		doinclude(trp, 0);
+		trp->lp = trp->bp;
+		return;
+
+	case KINCLUDE_NEXT:
+		doinclude(trp, 1);
 		trp->lp = trp->bp;
 		return;
 

--- a/sys/src/cmd/cpp/cpp.h
+++ b/sys/src/cmd/cpp/cpp.h
@@ -19,7 +19,7 @@ enum toktype { END, UNCLASS, NAME, NUMBER, STRING, CCON, NL, WS, DSHARP,
 		ASRSH, ASOR, ASAND, ELLIPS,
 		DSHARP1, NAME1, DEFINED, UMINUS };
 
-enum kwtype { KIF, KIFDEF, KIFNDEF, KELIF, KELSE, KENDIF, KINCLUDE, KDEFINE,
+enum kwtype { KIF, KIFDEF, KIFNDEF, KELIF, KELSE, KENDIF, KINCLUDE, KINCLUDE_NEXT, KDEFINE,
 		KUNDEF, KLINE, KERROR, KWARNING, KPRAGMA, KDEFINED,
 		KLINENO, KFILE, KDATE, KTIME, KSTDC, KEVAL };
 
@@ -62,6 +62,7 @@ typedef struct source {
 	int	fd;		/* input source */
 	int	ifdepth;	/* conditional nesting in include */
 	struct	source *next;	/* stack for #include */
+	int	pos;		/* next position for #include_next */
 } Source;
 
 typedef struct nlist {
@@ -109,7 +110,7 @@ Nlist	*lookup(Token *, int);
 void	control(Tokenrow *);
 void	dodefine(Tokenrow *);
 void	doadefine(Tokenrow *, int);
-void	doinclude(Tokenrow *);
+void	doinclude(Tokenrow *, int);
 void	doif(Tokenrow *, enum kwtype);
 void	expand(Tokenrow *, Nlist *, int);
 void	builtin(Tokenrow *, int);

--- a/sys/src/cmd/cpp/lex.c
+++ b/sys/src/cmd/cpp/lex.c
@@ -604,6 +604,7 @@ setsource(char *name, int fd, char *str)
 	s->ins = INS;	
 	s->inl = s->inp+len;
 	s->inl[0] = s->inl[1] = EOB;
+	s->pos = NINCLUDE; /* outside of include dirs */
 	return s;
 }
 

--- a/sys/src/cmd/cpp/nlist.c
+++ b/sys/src/cmd/cpp/nlist.c
@@ -29,6 +29,7 @@ struct	kwtab {
 	"else",		KELSE,		ISKW,
 	"endif",	KENDIF,		ISKW,
 	"include",	KINCLUDE,	ISKW,
+	"include_next",	KINCLUDE_NEXT,	ISKW,	// extension to ANSI
 	"define",	KDEFINE,	ISKW,
 	"undef",	KUNDEF,		ISKW,
 	"line",		KLINE,		ISKW,


### PR DESCRIPTION
Original post: 0intro/plan9-contrib#7
Also: https://9p.io/sources/patch/cpp-include-next/

----

I added `#include_next` directive that is GCC extension.
It is sometime used by sources that is developed for Unix, and can't ignore it easily.

I have tested it.

```c
// a.c
#include <u.h>

// compat/u.h
#ifndef U_H
#define U_H
#include "x.h"
#else
#include_next <u.h>
#endif

// x.h
#include_next <u.h>
```

```console
% cpp -N -Icompat -I/386/include/ape -I/sys/include/ape a.c
```