### PR TITLE
rc/bin/ape/install: add -d and allow two or more args

### DIFF
--- a/rc/bin/ape/install
+++ b/rc/bin/ape/install
@@ -3,35 +3,57 @@
 # Usage: install srcfile dstfile owner group mode
 
 fn usage {
-	echo 'usage: install [-c|-m mode] srcfile dstfile' >[1=2]
+	echo 'usage: install [-c|-d|-m mode] srcfile... dstfile' >[1=2]
 	exit 1
 }
 
+dir=()
 mode=775
 while(! ~ $#* 0){
 	switch($1){
 	case -c
 		;
+	case -d
+		dir=1
 	case -m
 		mode=$2
 		shift
 	case -*
 		usage
 	case *
-		switch($#*) {
-		case 2
-			;
-		case 5
-			mode=$5	# backward compatibility
-		case *
-			usage
+		if (~ $#dir 1) {
+			mkdir -p -m $mode $*
+			exit
 		}
-		srcfile=$1
-		dstfile=$2
-		if (! test -f $dstfile || ! cmp -s $srcfile $dstfile) {
+		switch($#*) {
+		case 1
+			usage
+		case 5
+			if (! test -d $5) {
+				mode=$5	# backward compatibility
+				*=($1 $2)
+			}
+		}
+		if (test -f $*($#*)) {
+			if (! ~ $#* 2)
+				usage
+			srcfile=$1
+			dstfile=$2
+			if (! cmp -s $srcfile $dstfile) {
+				cp $srcfile $dstfile
+				chmod $mode $dstfile
+				chmod g+w $dstfile
+			}
+			exit 0
+		}
+		i=`{echo $#* - 1 | hoc}
+		srcfiles=$*(1-$i)
+		dstfile=$*($#*)
+		for (srcfile in $srcfiles) {
+			f=$dstfile/^`{basename $srcfile}
 			cp $srcfile $dstfile
-			chmod $mode $dstfile
-			chmod g+w $dstfile
+			chmod $mode $f
+			chmod g+w $f
 		}
 		exit 0
 	}


### PR DESCRIPTION
Original post: 0intro/plan9-contrib#9

-----

### Motivation

Makefile of proper Git uses install -d and install [files...] dir patterns so I added these two patterns to ape/install.

### Valid command-line patterns
```sh
# copy a file to other file
install f o

# create one or more directories
install -d d1 d2

# copy one or more files into a directory
install a b c d/

# backward compatibility; copy a file to other file
install f o owner group mode # copy a to b

# but if last argument is a directory, copy files into a directory
install a b c d dir/
```