### PR TITLE
Google Cloud VPC network

### DIFF
--- a/sys/src/9/ip/ip.c
+++ b/sys/src/9/ip/ip.c
@@ -129,6 +129,7 @@ ipoput4(Fs *f, Block *bp, int gating, int ttl, int tos, Conv *c)
 	Route *r, *sr;
 	IP *ip;
 	int rv = 0;
+	uchar v4dst[IPv4addrlen];
 
 	ip = f->ip;
 
@@ -169,7 +170,11 @@ ipoput4(Fs *f, Block *bp, int gating, int ttl, int tos, Conv *c)
 		gate = eh->dst;
 	else
 	if(r->type & (Rbcast|Rmulti)) {
-		gate = eh->dst;
+		if(nhgetl(r->v4.gate) == 0){
+			hnputl(v4dst, r->v4.address);
+			gate = v4dst;
+		}else
+			gate = eh->dst;
 		sr = v4lookup(f, eh->src, nil);
 		if(sr != nil && (sr->type & Runi))
 			ifc = sr->ifc;

--- a/sys/src/9/ip/iproute.c
+++ b/sys/src/9/ip/iproute.c
@@ -493,6 +493,7 @@ v4lookup(Fs *f, uchar *a, Conv *c)
 		return c->r;
 
 	la = nhgetl(a);
+again:
 	q = nil;
 	for(p=f->v4root[V4H(la)]; p;)
 		if(la >= p->v4.address) {
@@ -511,8 +512,14 @@ v4lookup(Fs *f, uchar *a, Conv *c)
 		} else
 			v4tov6(gate, q->v4.gate);
 		ifc = findipifc(f, gate, q->type);
-		if(ifc == nil)
+		if(ifc == nil){
+			/* find a direct attached route */
+			if(q->v4.address == 0 && q->v4.endaddress == ~0){
+				la = nhgetl(q->v4.gate);
+				goto again;
+			}
 			return nil;
+		}
 		q->ifc = ifc;
 		q->ifcid = ifc->ifcid;
 	}
@@ -817,6 +824,7 @@ routewrite(Fs *f, Chan *c, char *p, int n)
 	uchar gate[IPaddrlen];
 	IPaux *a, *na;
 	Route *q;
+	uchar type;
 
 	cb = parsecmd(p, n);
 	if(waserror()){
@@ -863,9 +871,12 @@ routewrite(Fs *f, Chan *c, char *p, int n)
 			a = c->aux;
 			tag = a->tag;
 		}
-		if(memcmp(addr, v4prefix, IPv4off) == 0)
-			v4addroute(f, tag, addr+IPv4off, mask+IPv4off, gate+IPv4off, 0);
-		else
+		if(memcmp(addr, v4prefix, IPv4off) == 0){
+			type = 0;
+			if(ipcmp(mask, IPallbits) == 0)
+				type = Rbcast;
+			v4addroute(f, tag, addr+IPv4off, mask+IPv4off, gate+IPv4off, type);
+		}else
 			v6addroute(f, tag, addr, mask, gate, 0);
 	} else if(strcmp(cb->f[0], "tag") == 0) {
 		if(cb->nf < 2)

--- a/sys/src/cmd/ip/dhcp.h
+++ b/sys/src/cmd/ip/dhcp.h
@@ -115,6 +115,8 @@ enum
 	ODpxeni=		94,
 	ODpxeguid=		97,
 
+	ODcstaticroutes=	121, /* see rfc 3442 */
+
 	/* plan9 vendor info options, v4 addresses only (deprecated) */
 	OP9fsv4=		128,	/* plan9 file servers */
 	OP9authv4=		129,	/* plan9 auth servers */

--- a/sys/src/cmd/ip/ipconfig/ipconfig.h
+++ b/sys/src/cmd/ip/ipconfig/ipconfig.h
@@ -26,6 +26,7 @@ struct Conf
 	uchar	fs[2*IPaddrlen];
 	uchar	auth[2*IPaddrlen];
 	uchar	ntp[IPaddrlen];
+	uchar	iproutes[6*IPaddrlen]; /* mask, network, gateway */
 	int	mtu;
 
 	/* dhcp specific */

--- a/sys/src/cmd/ip/ipconfig/main.c
+++ b/sys/src/cmd/ip/ipconfig/main.c
@@ -1238,8 +1238,6 @@ dhcprecv(void)
 		if(!validip(conf.mask) || !Oflag){
 			if(!optgetaddr(bp->optdata, OBmask, conf.mask))
 				ipmove(conf.mask, IPnoaddr);
-			if(ipcmp(conf.mask, IPv4bcast) == 0)
-				ipmove(conf.mask, IPnoaddr);
 		}
 		DEBUG("ipaddr=%I ipmask=%M ", conf.laddr, conf.mask);
 


### PR DESCRIPTION
Original post: 0intro/plan9-contrib#12

----

On the Google Cloud, broadcasting packet can't reached to other instances in the same zone. Instead, all packets sent by the instance must communicate to other host via the default gateway.

The packet sent by DHCP server contains two Classless Static Routes(121) option.

```
[0]
mask=32
network=0.0.0.0
nexthop=10.xxx.xxx.1

[1]
mask=32
network=10.xxx.xxx.1
nexthop=0.0.0.0
```

`nexthop=0.0.0.0` means the route points to an interface.
https://www.cisco.com/c/en/us/support/docs/dial-access/floating-static-route/118263-technote-nexthop-00.html