### PR TITLE
implement some POSIX commands and options

### DIFF
--- a/rc/bin/ape/grep
+++ b/rc/bin/ape/grep
@@ -3,23 +3,27 @@
 rfork e
 
 opts=()
-files=()
-argv0=$0
-while(! ~ $#* 0){
-	switch($1){
-	case -e
-		opts=($opts $1 $2)
-		shift
-	case -[cfinsv]
-		opts=($opts $1)
-	case -q
-		opts=($opts -s)
-	case -*
-		echo $argv0 $1 not supported >[2=1]
-		exit 'not supported'
-	case *
-		files=($files $1)
-	}
-	shift
+flagfmt='c,e pattern,E,f patternfile,i,l,n,q,s,v'
+args='[file ...]'
+if(! ifs=() eval `{aux/getflags $*}){
+	aux/usage
+	eixt usage
 }
-exec /$cputype/bin/grep $opts $files
+chars=`{echo $flagfmt | sed 's/(.)[^,]*,/\1 /g'}
+for(i in $chars){
+	name=flag$i
+	switch($i){
+	case E
+		# ignore
+	case [ef]
+		if(! ~ $#$name 0)
+			opts=($opts -$i $$name)
+	case [qs]
+		if(! ~ $#$name 0 && ! ~ -s $opts)
+			opts=($opts -s)
+	case *
+		if(! ~ $#$name 0)
+			opts=($opts -$i)
+	}
+}
+exec /$cputype/bin/grep $opts $*

--- a/rc/bin/ape/printf
+++ b/rc/bin/ape/printf
@@ -1,4 +1,0 @@
-#!/bin/rc
-
-# Here only for autoconf and friends.
-echo -n $1

--- a/sys/src/ape/9src/tar.c
+++ b/sys/src/ape/9src/tar.c
@@ -15,7 +15,7 @@
 void
 usage(void)
 {
-	fprint(2, "usage: ape/tar [crtx][vfm] [args...] [file...]\n");
+	fprint(2, "usage: ape/tar [crtx][vfmop] [args...] [file...]\n");
 	exits("usage");
 }
 
@@ -73,7 +73,8 @@ main(int argc, char **argv)
 		case 'm':
 			Tflag = 0;
 			break;
-		case 'p':		/* pretend nothing's wrong */
+		case 'o':		/* pretend nothing's wrong */
+		case 'p':
 			break;
 		}
 	}

--- a/sys/src/ape/cmd/cut.c
+++ b/sys/src/ape/cmd/cut.c
@@ -1,0 +1,233 @@
+#include <u.h>
+#include <libc.h>
+#include <bio.h>
+
+void	usage(void);
+int	parselist(char *, long **);
+int	indexl(long *, long, int);
+int	cmpl(const void *, const void *);
+void	selectbytes(Biobuf*, int);
+void	selectrunes(Biobuf*, int);
+void	selectfields(Biobuf*, int);
+
+enum {
+	Listmax = 1<<10,
+};
+
+long *cols;
+int ncol;
+char *delims;
+
+void
+main(int argc, char **argv)
+{
+	Biobuf fout;
+	char *list;
+	int i, fd;
+	void (*filter)(Biobuf*, int);
+
+	delims = "\t";
+	list = nil;
+	filter = nil;
+	ARGBEGIN {
+	case 'b':
+		list = EARGF(usage());
+		filter = selectbytes;
+		break;
+	case 'c':
+		list = EARGF(usage());
+		filter = selectrunes;
+		break;
+	case 'd':
+		delims = EARGF(usage());
+		if(strlen(delims) != 1){
+			fprint(2, "%s: bad delimiter\n", argv0);
+			exits("usage");
+		}
+		break;
+	case 'f':
+		list = EARGF(usage());
+		filter = selectfields;
+		break;
+	default:
+		usage();
+	} ARGEND
+	if(list == nil)
+		usage();
+
+	ncol = parselist(list, &cols);
+	if(ncol < 0)
+		sysfatal("list '%s': %r", list);
+	Binit(&fout, 1, OWRITE);
+	if(argc == 0)
+		filter(&fout, 0);
+	else
+		for(i = 0; i < argc; i++){
+			fd = open(argv[i], OREAD);
+			if(fd < 0)
+				sysfatal("open: %r");
+			filter(&fout, fd);
+			close(fd);
+		}
+	exits(nil);
+}
+
+void
+usage(void)
+{
+	fprint(2, "usage: %s {-[b|c|f] list} [-d delim] [file ...]\n", argv0);
+	exits("usage");
+}
+
+int
+parselist(char *s, long **a)
+{
+	int n, u;
+	long v, r, d;
+
+	n = 1;
+	u = 0;
+	*a = malloc(sizeof(**a) * n);
+	if(*a == nil)
+		sysfatal("malloc: %r");
+	while(*s){
+		if(*s == '-')
+			v = 0;
+		else{
+			v = strtol(s, &s, 10);
+			if(n <= 0){
+				werrstr("value may not include zero");
+				return -1;
+			}
+			v--;
+		}
+		if(*s != '-')
+			r = v+1;
+		else{
+			r = strtol(s+1, &s, 10);
+			if(r < 0){
+				werrstr("illegal list value");
+				return -1;
+			}
+			if(r == 0)
+				r = Listmax;
+		}
+		d = r-v;
+		if(d < 0)
+			d = 0;
+		if(u+d >= n){
+			n = n*2 + d;
+			*a = realloc(*a, sizeof(**a)*n);
+			if(*a == nil)
+				sysfatal("realloc: %r");
+		}
+		while(r-- > v)
+			if(indexl(*a, r, u) < 0)
+				(*a)[u++] = r;
+		if(*s == ' ' || *s == ',')
+			s++;
+	}
+	qsort(*a, u, sizeof **a, cmpl);
+	return u;
+}
+
+int
+indexl(long *a, long v, int n)
+{
+	int i;
+
+	for(i = 0; i < n; i++)
+		if(a[i] == v)
+			return i;
+	return -1;
+}
+
+int
+cmpl(const void *a, const void *b)
+{
+	long n1, n2;
+
+	n1 = *(long *)a;
+	n2 = *(long *)b;
+	if(n1 < n2)
+		return -1;
+	else if(n1 == n2)
+		return 0;
+	else
+		return 1;
+}
+
+void
+selectbytes(Biobuf *w, int fd)
+{
+	Biobuf b;
+	char *s;
+	long *p, *e;
+
+	Binit(&b, fd, OREAD);
+	while(s = Brdline(&b, '\n')){
+		s[Blinelen(&b)-1] = '\0';
+		e = cols + ncol;
+		for(p = cols; p < e; p++){
+			if(*p >= strlen(s))
+				break;
+			Bputc(w, s[*p]);
+		}
+		Bputc(w, '\n');
+		Bflush(w);
+	}
+}
+
+void
+selectrunes(Biobuf *w, int fd)
+{
+	Biobuf b;
+	char *s;
+	Rune *r, *rp;
+	long *p, *e;
+
+	Binit(&b, fd, OREAD);
+	while(s = Brdline(&b, '\n')){
+		s[Blinelen(&b)-1] = '\0';
+		r = malloc(strlen(s) * sizeof *r);
+		if(r == nil)
+			sysfatal("malloc: %r");
+		rp = r;
+		while(*s)
+			s += chartorune(rp++, s);
+		e = cols + ncol;
+		for(p = cols; p < e; p++){
+			if(*p >= runestrlen(r))
+				break;
+			Bputrune(w, r[*p]);
+		}
+		free(r);
+		Bputc(w, '\n');
+		Bflush(w);
+	}
+}
+
+void
+selectfields(Biobuf *w, int fd)
+{
+	Biobuf b;
+	char *s, *a[Listmax];
+	int na;
+	long *p, *e;
+
+	Binit(&b, fd, OREAD);
+	while(s = Brdline(&b, '\n')){
+		s[Blinelen(&b)-1] = '\0';
+		na = getfields(s, a, nelem(a), 0, delims);
+		e = cols + ncol;
+		for(p = cols; p < e; p++){
+			if(*p >= na)
+				break;
+			if(p > cols) /* p is not first field */
+				Bprint(w, "%s", delims);
+			Bprint(w, "%s", a[*p]);
+		}
+		Bputc(w, '\n');
+		Bflush(w);
+	}
+}

--- a/sys/src/ape/cmd/mkfile
+++ b/sys/src/ape/cmd/mkfile
@@ -5,6 +5,7 @@ TARG=basename\
 	cc\
 	dirname\
 	kill\
+	printf\
 	uname
 
 DIRS=\
@@ -49,6 +50,12 @@ cc.$O: cc.c
 
 $O.cc: cc.$O
 	mk -f /sys/src/cmd/mkfile $O.cc
+
+printf.$O: printf.c
+	mk -f /sys/src/cmd/mkfile printf.$O
+
+$O.printf: printf.$O
+	mk -f /sys/src/cmd/mkfile $O.printf
 
 install.rc:V: $BIN/psh
 

--- a/sys/src/ape/cmd/mkfile
+++ b/sys/src/ape/cmd/mkfile
@@ -3,6 +3,7 @@ APE=/sys/src/ape
 
 TARG=basename\
 	cc\
+	cut\
 	dirname\
 	kill\
 	printf\
@@ -50,6 +51,12 @@ cc.$O: cc.c
 
 $O.cc: cc.$O
 	mk -f /sys/src/cmd/mkfile $O.cc
+
+cut.$O: cut.c
+	mk -f /sys/src/cmd/mkfile cut.$O
+
+$O.cut: cut.$O
+	mk -f /sys/src/cmd/mkfile $O.cut
 
 printf.$O: printf.c
 	mk -f /sys/src/cmd/mkfile printf.$O

--- a/sys/src/ape/cmd/printf.c
+++ b/sys/src/ape/cmd/printf.c
@@ -1,0 +1,239 @@
+#include <u.h>
+#include <libc.h>
+#ifdef PLAN9PORT
+#include <libString.h>
+#else
+#include <String.h>
+#endif
+#include <bio.h>
+
+void	usage(void);
+void	xprintf(char *, int, char **);
+int	puto(Biobuf *, char *);
+int	putx(Biobuf *, char *);
+int	cton(char);
+int	format(Biobuf *, char *, char **, char **);
+int	result(String *, char *, char **, int);
+
+void
+main(int argc, char **argv)
+{
+	ARGBEGIN {
+	default:
+		usage();
+	} ARGEND
+	if(argc == 0)
+		usage();
+	xprintf(*argv, argc-1, argv+1);
+	exits(nil);
+}
+
+void
+usage(void)
+{
+	fprint(2, "usage: %s format [arg ...]\n", argv0);
+	exits("usage");
+}
+
+void
+xprintf(char *fmt, int narg, char **args)
+{
+	Biobuf b;
+	char c, c1;
+	int n;
+
+	Binit(&b, 1, OWRITE);
+	while(c = *fmt++){
+		if(c == '\\'){
+			c1 = *fmt++;
+			switch(c1){
+			default:
+				Bputc(&b, c);
+				Bputc(&b, c1);
+				break;
+			case '"':
+			case '\\':
+				Bputc(&b, c1);
+				break;
+			case 'a':
+				Bputc(&b, '\a');
+				break;
+			case 'b':
+				Bputc(&b, '\b');
+				break;
+			case 'c':
+				goto end;
+			case 'f':
+				Bputc(&b, '\f');
+				break;
+			case 'n':
+				Bputc(&b, '\n');
+				break;
+			case 'r':
+				Bputc(&b, '\r');
+				break;
+			case 't':
+				Bputc(&b, '\t');
+				break;
+			case 'v':
+				Bputc(&b, '\v');
+				break;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+				fmt--;
+				n = puto(&b, fmt);
+				if(n > 0)
+					fmt += n;
+				break;
+			case 'x':
+				n = putx(&b, fmt);
+				if(n > 0)
+					fmt += n;
+				break;
+			}
+		}else if(c == '%'){
+			n = format(&b, fmt, &fmt, args);
+			if(n > 0){
+				narg -= n;
+				args += n;
+			}
+		}else
+			Bputc(&b, c);
+	}
+end:
+	Bflush(&b);
+}
+
+int
+puto(Biobuf *b, char *s)
+{
+	int c, x;
+	char *p, *e;
+
+	c = 0;
+	e = s + 3;
+	for(p = s; p < e && *p; p++){
+		x = cton(*p);
+		if(x < 0 || x >= 8)
+			break;
+		c <<= 3;
+		c |= x;
+	}
+	Bputc(b, c);
+	return p - s;
+}
+
+int
+putx(Biobuf *b, char *s)
+{
+	int c, x;
+	char *p, *e;
+
+	c = 0;
+	e = s + 2;
+	for(p = s; p < e && *p; p++){
+		x = cton(*p);
+		if(x < 0 || x >= 16)
+			break;
+		c <<= 4;
+		c |= x;
+	}
+	Bputc(b, c);
+	return p - s;
+}
+
+int
+cton(char c)
+{
+	if(c >= '0' && c <= '9')
+		return c - '0';
+	if(c >= 'A' && c <= 'Z')
+		return c - 'A' + 10;
+	if(c >= 'a' && c <= 'z')
+		return c - 'a' + 10;
+	return -1;
+}
+
+int
+format(Biobuf *b, char *s, char **pp, char **args)
+{
+	String *fmt;
+	char c, *p, buf[100], **ap;
+	int n;
+	vlong v;
+	uvlong u;
+	double d;
+
+	ap = args;
+	fmt = s_copy("%");
+	if(fmt == nil)
+		sysfatal("s_copy: %r");
+	p = s;
+	while(c = *p++)
+		if(strchr("-+ #0123456789hl.", c))
+			s_putc(fmt, c);
+		else if(c == '*'){
+			n = 0;
+			if(*ap)
+				n = atoi(*ap++);
+			snprint(buf, sizeof buf, "%d", n);
+			s_append(fmt, buf);
+		}else if(c == 'd' || c == 'i'){
+			s_putc(fmt, c);
+			s_terminate(fmt);
+			v = 0LL;
+			if(*ap)
+				v = strtoll(*ap++, nil, 0);
+			Bprint(b, s_to_c(fmt), v);
+			return result(fmt, p, pp, ap - args);
+		}else if(strchr("ouxX", c)){
+			s_putc(fmt, c);
+			s_terminate(fmt);
+			u = 0ULL;
+			if(*ap)
+				u = strtoull(*ap++, nil, 0);
+			Bprint(b, s_to_c(fmt), u);
+			return result(fmt, p, pp, ap - args);
+		}else if(strchr("fFeEgG", c)){
+			s_putc(fmt, c);
+			s_terminate(fmt);
+			d = 0.0;
+			if(*ap)
+				d = strtod(*ap++, nil);
+			Bprint(b, s_to_c(fmt), d);
+			return result(fmt, p, pp, ap - args);
+		}else if(c == 'c'){
+			s_putc(fmt, c);
+			s_terminate(fmt);
+			Bprint(b, s_to_c(fmt), *ap ? **ap : '\0');
+			if(*ap)
+				ap++;
+			return result(fmt, p, pp, ap - args);
+		}else if(c == 's'){
+			s_putc(fmt, c);
+			s_terminate(fmt);
+			Bprint(b, s_to_c(fmt), *ap ? *ap : "");
+			if(*ap)
+				ap++;
+			return result(fmt, p, pp, ap - args);
+		}else
+			break;
+
+	fprint(2, "%s: %%%s: invalid directive\n", argv0, s);
+	exits("format");
+	return -1;
+}
+
+int
+result(String *fmt, char *s, char **pp, int d)
+{
+	s_free(fmt);
+	*pp = s;
+	return d;
+}


### PR DESCRIPTION
Original post: 0intro/plan9-contrib#13

-----

### printf
I've tested with this rc script.

```sh
#!/bin/rc

rfork e

test_dfmt=('%d' 30)
test_ffmt=('%.3f' 2.4)
test_gfmt=('%g' 293847595998)
test_sfmt=('%.2s%5s' abv z)
test_cfmtz=('%c')
test_sfmtz=('%s')
test_Xfmtz=('%X')
test_hex=('%x' 0x32)
test_oct=('%o' 033)
test_esc=('\x40\618\0623\t\r\n')

tests=(\
	test_dfmt\
	test_ffmt\
	test_gfmt\
	test_sfmt\
	test_cfmtz\
	test_sfmtz\
	test_Xfmtz\
	test_hex\
	test_oct\
	test_esc\
)

old=/usr/bin/printf
new=./a.out

for(i in $tests){
	if(! cmp -s <{$old $$i} <{$new $$i}){
		echo printf $$i
		diff -u <{$old $$i} <{$new $$i}
	}
}
```

### cut
```sh
#!/bin/rc

rfork e

test_fields=('a	b	c	d' -f 2,3)
test_bytes=(1234 -b 1-3)
test_runes=(こんにちは -c 1-2,4)
test_delim=('1:2:a	b' -d : -f 3)
tests=(\
	test_fields\
	test_bytes\
	test_delim\
)

old=cut
new=./a.out

for(i in $tests){
	a=$$i
	text=$a(1)
	opts=$a(2-)
	fn ocut {
		echo $text | $old $opts
	}
	fn ncut {
		echo $text | $new $opts
	}
	if(! cmp -s <{ocut} <{ncut}){
		echo echo $text '|' cut $opts
		diff -u <{ocut} <{ncut}
	}
}
```