### PR TITLE
sys/src/cmd/cc: add -u option

### DIFF
--- a/sys/src/cmd/cc/dcl.c
+++ b/sys/src/cmd/cc/dcl.c
@@ -934,10 +934,21 @@ sametype(Type *t1, Type *t2)
 	return rsametype(t1, t2, 5, 1);
 }
 
+long	typesign[] =
+{
+	BCHAR|BUCHAR,
+	BSHORT|BUSHORT,
+	BINT|BUINT,
+	BLONG|BULONG,
+	BVLONG|BUVLONG,
+	0,
+};
+
 int
 rsametype(Type *t1, Type *t2, int n, int f)
 {
 	int et;
+	long b1, b2, *p;
 
 	n--;
 	for(;;) {
@@ -1006,6 +1017,16 @@ rsametype(Type *t1, Type *t2, int n, int f)
 				return 1;
 			if(t2 != T && t2->etype == TVOID)
 				return 1;
+		}
+		if(debug['u'] && et == TIND) {
+			b1 = b2 = ~0;
+			if(t1 != T)
+				b1 = 1L<<t1->etype;
+			if(t2 != T)
+				b2 = 1L<<t2->etype;
+			for(p = typesign; *p; p++)
+				if(((b1|b2) & ~*p) == 0)
+					return 1;
 		}
 	}
 }

--- a/sys/src/cmd/cc/lex.c
+++ b/sys/src/cmd/cc/lex.c
@@ -26,6 +26,7 @@
  *	-s		print structure offsets (with -a or -aa)
  *	-S		print assembly
  *	-t		print type trees
+ *	-u		enable implicit conversion between type* and utype*
  *	-V		enable void* conversion warnings
  *	-v		verbose printing
  *	-w		print warnings

--- a/sys/src/cmd/pcc.c
+++ b/sys/src/cmd/pcc.c
@@ -79,6 +79,7 @@ main(int argc, char *argv[])
 			if(!oname)
 				fatal("no -o argument");
 			break;
+		case 'u':
 		case 'w':
 		case 'B':
 		case 'F':


### PR DESCRIPTION
There are many expressions to convert implicitly between `char*` and `uchar*` in LibreSSL Portable.
See libressl-portable/portable#510