### PR TITLE
sys/include/ape: add BYTE_ORDER

### DIFF
--- a/386/include/ape/_apetypes.h
+++ b/386/include/ape/_apetypes.h
@@ -1,7 +1,0 @@
-#if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
-#define	__BYTE_ORDER	__LITTLE_ENDIAN
-#endif
-
-#if !defined(BYTE_ORDER) && defined(LITTLE_ENDIAN)
-#define	BYTE_ORDER	LITTLE_ENDIAN
-#endif

--- a/386/include/ape/_endian.h
+++ b/386/include/ape/_endian.h
@@ -1,0 +1,5 @@
+#ifndef _ENDIAN_H_
+   This header file is expected to include only from machine/endian.h
+#endif
+
+#define __BYTE_ORDER	__LITTLE_ENDIAN

--- a/amd64/include/ape/_apetypes.h
+++ b/amd64/include/ape/_apetypes.h
@@ -1,11 +1,3 @@
 #ifndef _BITS64
 #define _BITS64
 #endif
-
-#if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
-#define	__BYTE_ORDER	__LITTLE_ENDIAN
-#endif
-
-#if !defined(BYTE_ORDER) && defined(LITTLE_ENDIAN)
-#define	BYTE_ORDER	LITTLE_ENDIAN
-#endif

--- a/amd64/include/ape/_endian.h
+++ b/amd64/include/ape/_endian.h
@@ -1,0 +1,5 @@
+#ifndef _ENDIAN_H_
+   This header file is expected to include only from machine/endian.h
+#endif
+
+#define __BYTE_ORDER	__LITTLE_ENDIAN

--- a/arm/include/ape/_endian.h
+++ b/arm/include/ape/_endian.h
@@ -1,0 +1,5 @@
+#ifndef _ENDIAN_H_
+   This header file is expected to include only from machine/endian.h
+#endif
+
+#define __BYTE_ORDER	__LITTLE_ENDIAN

--- a/mips/include/ape/_endian.h
+++ b/mips/include/ape/_endian.h
@@ -1,0 +1,5 @@
+#ifndef _ENDIAN_H_
+   This header file is expected to include only from machine/endian.h
+#endif
+
+#define __BYTE_ORDER	__BIG_ENDIAN

--- a/mips64/include/ape/_endian.h
+++ b/mips64/include/ape/_endian.h
@@ -1,0 +1,5 @@
+#ifndef _ENDIAN_H_
+   This header file is expected to include only from machine/endian.h
+#endif
+
+#define __BYTE_ORDER	__BIG_ENDIAN

--- a/power/include/ape/_endian.h
+++ b/power/include/ape/_endian.h
@@ -1,0 +1,5 @@
+#ifndef _ENDIAN_H_
+   This header file is expected to include only from machine/endian.h
+#endif
+
+#define __BYTE_ORDER	__BIG_ENDIAN

--- a/power64/include/ape/_endian.h
+++ b/power64/include/ape/_endian.h
@@ -1,0 +1,5 @@
+#ifndef _ENDIAN_H_
+   This header file is expected to include only from machine/endian.h
+#endif
+
+#define __BYTE_ORDER	__BIG_ENDIAN

--- a/riscv/include/ape/_endian.h
+++ b/riscv/include/ape/_endian.h
@@ -1,0 +1,5 @@
+#ifndef _ENDIAN_H_
+   This header file is expected to include only from machine/endian.h
+#endif
+
+#define __BYTE_ORDER	__LITTLE_ENDIAN

--- a/riscv64/include/ape/_endian.h
+++ b/riscv64/include/ape/_endian.h
@@ -1,0 +1,5 @@
+#ifndef _ENDIAN_H_
+   This header file is expected to include only from machine/endian.h
+#endif
+
+#define __BYTE_ORDER	__LITTLE_ENDIAN

--- a/sparc/include/ape/_endian.h
+++ b/sparc/include/ape/_endian.h
@@ -1,0 +1,5 @@
+#ifndef _ENDIAN_H_
+   This header file is expected to include only from machine/endian.h
+#endif
+
+#define __BYTE_ORDER	__BIG_ENDIAN

--- a/spim/include/ape/_endian.h
+++ b/spim/include/ape/_endian.h
@@ -1,0 +1,5 @@
+#ifndef _ENDIAN_H_
+   This header file is expected to include only from machine/endian.h
+#endif
+
+#define __BYTE_ORDER	__LITTLE_ENDIAN

--- a/spim64/include/ape/_endian.h
+++ b/spim64/include/ape/_endian.h
@@ -1,0 +1,5 @@
+#ifndef _ENDIAN_H_
+   This header file is expected to include only from machine/endian.h
+#endif
+
+#define __BYTE_ORDER	__LITTLE_ENDIAN

--- a/sys/include/ape/machine/endian.h
+++ b/sys/include/ape/machine/endian.h
@@ -1,10 +1,15 @@
 #ifndef _ENDIAN_H_
 #define _ENDIAN_H_
 
-#define LITTLE_ENDIAN	1234
-#define BIG_ENDIAN	4321
-#define PDP_ENDIAN	3412
+#define __LITTLE_ENDIAN	1234
+#define __BIG_ENDIAN	4321
+#define __PDP_ENDIAN	3412
 
-#include "_apetypes.h"
+#include <_endian.h>
+
+#define LITTLE_ENDIAN	__LITTLE_ENDIAN
+#define BIG_ENDIAN	__BIG_ENDIAN
+#define PDP_ENDIAN	__PDP_ENDIAN
+#define BYTE_ORDER	__BYTE_ORDER
 
 #endif


### PR DESCRIPTION
The **_apetypes.h** headers will be removed at the commit ce80554.
