### PR TITLE
rc/bin/ape/grep: always use native sed

### DIFF
--- a/rc/bin/ape/grep
+++ b/rc/bin/ape/grep
@@ -9,7 +9,7 @@ if(! ifs=() eval `{aux/getflags $*}){
 	aux/usage
 	eixt usage
 }
-chars=`{echo $flagfmt | sed 's/(.)[^,]*,/\1 /g'}
+chars=`{echo $flagfmt | /$cputype/bin/sed 's/(.)[^,]*,/\1 /g'}
 for(i in $chars){
 	name=flag$i
 	switch($i){


### PR DESCRIPTION
In ape/psh, the sed command is replaced by ape/sed.
