### PR TITLE
revert the patch: rc-line-split

### DIFF
--- a/sys/man/1/rc
+++ b/sys/man/1/rc
@@ -233,8 +233,6 @@ The value is a single string containing the components of the named variable
 separated by spaces.  A variable with zero elements yields the empty string.
 .HP
 .BI `{ command }
-.HP
-.BI ` "split " { command }
 .br
 .I rc
 executes the
@@ -247,8 +245,6 @@ If
 .B $ifs
 is not otherwise set, its value is
 .BR "'\ \et\en'" .
-In the second form of the command, split is used instead of
-.BR $ifs .
 .HP
 .BI <{ command }
 .HP

--- a/sys/src/cmd/rc/code.c
+++ b/sys/src/cmd/rc/code.c
@@ -94,8 +94,6 @@ outcode(tree *t, int eflag)
 {
 	int p, q;
 	tree *tt;
-	char *ifs;
-
 	if(t==0)
 		return;
 	if(t->type!=NOT && t->type!=';')
@@ -143,22 +141,10 @@ outcode(tree *t, int eflag)
 		emitf(Xconc);
 		break;
 	case '`':
- 		emitf(Xmark);
- 		if(c0){
- 			outcode(c0, 0);
- 			emitf(Xglob);
- 		} else {
-			if((ifs = strdup("ifs")) == nil)
-				sysfatal("strdup: %r");
- 			emitf(Xmark);
- 			emitf(Xword);
- 			emits(ifs);
- 			emitf(Xdol);
- 		}
 		emitf(Xbackq);
 		if(havefork){
 			p = emiti(0);
-			outcode(c1, 0);
+			outcode(c0, 0);
 			emitf(Xexit);
 			stuffdot(p);
 		} else

--- a/sys/src/cmd/rc/exec.c
+++ b/sys/src/cmd/rc/exec.c
@@ -239,7 +239,7 @@ main(int argc, char *argv[])
  * Xappend(file)[fd]			open file to append
  * Xassign(name, val)			assign val to name
  * Xasync{... Xexit}			make thread for {}, no wait
- * Xbackq(split){... Xreturn}		make thread for {}, push stdout
+ * Xbackq{... Xreturn}			make thread for {}, push stdout
  * Xbang				complement condition
  * Xcase(pat, value){...}		exec code on match, leave (value) on
  * 					stack

--- a/sys/src/cmd/rc/havefork.c
+++ b/sys/src/cmd/rc/havefork.c
@@ -82,12 +82,11 @@ Xbackq(void)
 	char *stop;
 	char utf[UTFmax+1];
 	io *f, *wd;
+	var *ifs = vlook("ifs");
 	word *v, *nextv;
 	Rune r;
 
- 	stop = "";
- 	if(runq->argv && runq->argv->words)
- 		stop = runq->argv->words->word;	
+	stop = ifs->val? ifs->val->word: "";
 	if(pipe(pfd)<0){
 		Xerror("can't make pipe");
 		return;
@@ -130,7 +129,6 @@ Xbackq(void)
 		closeio(wd);
 		closeio(f);
 		Waitfor(pid, 0);
-		poplist();	/* ditch split in "stop" */
 		/* v points to reversed arglist -- reverse it onto argv */
 		while(v){
 			nextv = v->next;

--- a/sys/src/cmd/rc/pcmd.c
+++ b/sys/src/cmd/rc/pcmd.c
@@ -33,7 +33,7 @@ pcmd(io *f, tree *t)
 	break;
 	case '^':	pfmt(f, "%t^%t", c0, c1);
 	break;
-	case '`':	pfmt(f, "`%t%t", c0, c1);
+	case '`':	pfmt(f, "`%t", c0);
 	break;
 	case ANDAND:	pfmt(f, "%t && %t", c0, c1);
 	break;

--- a/sys/src/cmd/rc/syn.y
+++ b/sys/src/cmd/rc/syn.y
@@ -83,8 +83,7 @@ comword: '$' word		{$$=tree1('$', $2);}
 |	'"' word		{$$=tree1('"', $2);}
 |	COUNT word		{$$=tree1(COUNT, $2);}
 |	WORD
-|	'`' brace		{$$=tree2('`', (struct tree*)0, $2);}
-|	'`' word brace		{$$=tree2('`', $2, $3);}
+|	'`' brace		{$$=tree1('`', $2);}
 |	'(' words ')'		{$$=tree1(PAREN, $2);}
 |	REDIRW brace		{$$=mung1($1, $2); $$->type=PIPEFD;}
 keyword: FOR|IN|WHILE|IF|NOT|TWIDDLE|BANG|SUBSHELL|SWITCH|FN


### PR DESCRIPTION
The patch conflicts russ's equal-sign modifications I imported. So I decided to drops it temporarily.
It contains 338bd13fe81e7dfa865566d483317d5e0838fff1