### PR TITLE
drop ether drivers from 9boot

### DIFF
--- a/sys/src/9/pcboot/boot
+++ b/sys/src/9/pcboot/boot
@@ -15,32 +15,7 @@ link
 # order of ethernet drivers should match that in ../pc/pc so that
 # devices are detected in the same order by bootstraps and kernels
 # and thus given the same controller numbers.
-	ether2000	ether8390
-	ether2114x	pci
-	ether589	etherelnk3
-	ether79c970	pci
-	ether8003	ether8390
-	ether8139	pci
-	ether8169	pci ethermii
-	ether82543gc	pci
-	ether82557	pci
-	ether82563	pci
-	ether83815	pci
-	etherdp83820	pci
-	etherec2t	ether8390
-	etherelnk3	pci
-	etherga620	pci
-	etherigbe	pci ethermii
-	ethervgbe	pci ethermii
-	ethervt6102	pci ethermii
-	ethervt6105m	pci ethermii
-#	ethersink
-	ethersmc	devi82365 cis
-	etherwavelan	wavelan devi82365 cis pci
-	etherm10g
-	ether82598	pci
 	ethervirtio	pci
-
 	ethermedium
 
 misc

--- a/sys/src/9/pcboot/bootmkfile
+++ b/sys/src/9/pcboot/bootmkfile
@@ -2,7 +2,7 @@
 # inherit KTZERO, START, CONF, BASE and SFX from mkfile
 x=`{bindpc $BASE $SFX}
 CONFLIST=$CONF
-EXTRACOPIES=piestand lookout bovril boundary 
+EXTRACOPIES=
 
 objtype=386
 </$objtype/mkfile


### PR DESCRIPTION
I imported these commits:

* https://github.com/rsc/plan9/commit/4e1bb6a27300d93ec86a53bbcc774efbb0a60778
* https://github.com/rsc/plan9/commit/32a1bdfb506bba33a7f08937518fbc6487d1453b