### PR TITLE
sys/src/ape/lib/ap/amd64: fix unexpected argc

### DIFF
--- a/sys/src/ape/lib/ap/amd64/main9.s
+++ b/sys/src/ape/lib/ap/amd64/main9.s
@@ -5,6 +5,7 @@
 	LEAQ	inargv+0(FP), AX
 	MOVQ	AX, 8(SP)
 	CALL	_init(SB)
+	MOVL	inargc-8(FP), RARG
 	MOVQ	environ(SB), AX
 	MOVQ	AX, 16(SP)
 	CALL	main(SB)

--- a/sys/src/ape/lib/ap/amd64/main9p.s
+++ b/sys/src/ape/lib/ap/amd64/main9p.s
@@ -27,6 +27,7 @@ TEXT	_mainp(SB), 1, $(3*8+NPRIVATES*8)
 	LEAQ	inargv+0(FP), AX
 	MOVQ	AX, 8(SP)
 	CALL	_init(SB)
+	MOVL	inargc-8(FP), RARG
 	MOVQ	environ(SB), AX
 	MOVQ	AX, 16(SP)
 	CALL	main(SB)


### PR DESCRIPTION
On amd64, first argument is set to RARG register.

Its register is changed by function calling in *_init* so it was changed to unexpected value when *main* is calling.