### PR TITLE
sys/src/cmd/auth/factotum: fix a crash bug

### DIFF
--- a/sys/src/cmd/auth/factotum/totp.c
+++ b/sys/src/cmd/auth/factotum/totp.c
@@ -139,7 +139,7 @@ totpinit(Proto *p, Fsstate *fss)
 
 	if(iscli){
 		phase = CHaveResp;
-		ret = findkey(&k, mkkeyinfo(&ki, fss, nil), "%s", fss->proto->keyprompt);
+		ret = findkey(&k, mkkeyinfo(&ki, fss, nil), "%s", p->keyprompt);
 	}else{
 		phase = SNeedResp;
 		ret = findkey(&k, mkkeyinfo(&ki, fss, nil), nil);
@@ -159,7 +159,7 @@ totpinit(Proto *p, Fsstate *fss)
 	setattrs(fss->attr, k->attr);
 	s = emalloc(sizeof *s + n);
 	s->key = k;
-	s->data = (uchar*)(p+1);
+	s->data = (uchar*)(s+1);
 	memmove(s->data, key, n);
 	s->n = n;
 	fss->ps = s;


### PR DESCRIPTION
I fixed a bug of totp/factotum.

```console
% acid 46023
/proc/46023/text:386 plan 9 executable
/sys/lib/acid/port
/sys/lib/acid/386
acid: lstk()
strcmp(s1=0x4117c6b,s2=0x3e328)+0xe /sys/src/libc/port/strcmp.c:10
ignoreattr(s=0x3e328)+0x25 /sys/src/cmd/auth/factotum/util.c:307
	i=0x0
matchattr(pat=0x3e2e8,a0=0x3d9e8,a1=0x3da68)+0x21 /sys/src/cmd/auth/factotum/util.c:546
	type=0x0
findkey(ki=0xdfffeb68,fmt=0x3738a,ret=0xdfffeb80)+0x1c3 /sys/src/cmd/auth/factotum/util.c:372
	who=0x0
	attr0=0x3e2e8
	buf=0x72657375
	arg=0xdfffeb5c
	attr1=0x3ea48
	attr2=0x0
	attr3=0x0
	p=0x3e348
	nmatch=0x0
	i=0x0
	k=0x3d648
	s=0x0
	l=0x3e7a8
totpinit(fss=0x53d58,p=0x3713c)+0xcd /sys/src/cmd/auth/factotum/totp.c:142
	phase=0x0
	ki=0x53d58
	k=0x0
	secret=0x3e328
	key=0x14
	n=0x3e348
	s=0x3e8c8
rpcread(r=0x3de68)+0x47b /sys/src/cmd/auth/factotum/rpc.c:289
	fss=0x53d58
	attr=0x3e2e8
	p=0x3e348
	ret=0x54fd8
	count=0x54fd0
	ophase=0x0
	e=0x11907
fsread(r=0x3de68)+0x9f /sys/src/cmd/auth/factotum/fs.c:536
	s=0x54fd8
sread(srv=0x31544,r=0x3de68)+0x145 /sys/src/lib9p/srv.c:495
srv(srv=0x31544)+0x1fc /sys/src/lib9p/srv.c:708
postproc(v=0x31544)+0x4f /sys/src/lib9p/post.c:70
	s=0x31544
rforker(arg=0x31544,fn=0x2a14e,flag=0x1)+0x2d /sys/src/lib9p/rfork.c:17
_postmountsrv(s=0x31544,name=0x0,mtpt=0x363e8,flag=0x1)+0xbd /sys/src/lib9p/post.c:27
	fd=0x4
postmountsrv(s=0x31544,name=0x0,mtpt=0x363e8,flag=0x1)+0x32 /sys/src/lib9p/rfork.c:32
main(argv=0xdfffef9c,argc=0x0)+0x351 /sys/src/cmd/auth/factotum/fs.c:185
	trysecstore=0x1
	secstorepw=0x0
	_argc=0x70
	_args=0xdfffefb7
	i=0xf
	p=0x34bd8
	s=0x0
	err=0x0
	d=0x0
_main+0x31 /sys/src/libc/386/main9.s:16
```
