### PR TITLE
sys/src/9k/k10: refine parameters

### DIFF
--- a/cfg/pxe/525400123456
+++ b/cfg/pxe/525400123456
@@ -7,6 +7,7 @@ menuitem=text, Plan 9 Text Mode
 mouseport=ps2intellimouse
 monitor=vesa
 vgasize=1920x1080x32
+nobootprompt=tcp
 
 [safe]
 mouseport=ps2
@@ -21,9 +22,8 @@ vgasize=none
 debugboot=1
 
 [common]
+bootfile=ether0!/386/9pc
 bootfile=ether0!/amd64/9k10
-bootfile=ether0!/amd64/9k10
-bootargs=tcp
 fs=10.0.2.1
 auth=10.0.2.1
 sysname=gnot

--- a/sys/src/9k/k10/k10
+++ b/sys/src/9k/k10/k10
@@ -201,4 +201,3 @@ lib
 	libsec
 	libmp
 	libc
-

--- a/sys/src/9k/k10/mkfile
+++ b/sys/src/9k/k10/mkfile
@@ -1,7 +1,7 @@
 ARCH=k10
-CONF=${ARCH}cpu
-CONFLIST=${ARCH}aoe ${ARCH}cpu ${ARCH}root ${ARCH}time
-EXTRACOPIES=piestand lookout bovril boundary
+CONF=${ARCH}
+CONFLIST=${ARCH} ${ARCH}f ${ARCH}aoe ${ARCH}cpu ${ARCH}root ${ARCH}time
+EXTRACOPIES=
 
 objtype=amd64
 </$objtype/mkfile


### PR DESCRIPTION
Build and boot parameters are copyed from https://github.com/rsc/plan9/commit/ae3a68626461b4eb739893e55fe36b9d3ac37403