### PR TITLE
sys/src/9k/386: discover uarts

### DIFF
--- a/sys/src/9k/386/uarti8250.c
+++ b/sys/src/9k/386/uarti8250.c
@@ -653,12 +653,9 @@ i8250pnp(void)
 		 */
 		uart = &i8250uart[i];
 		ctlr = uart->regs;
-		if (0) {
-			csr8o(ctlr, Scr, 0x55);
-			if(csr8r(ctlr, Scr) == 0x55)
-				continue;
-		}
-		if(ioalloc(ctlr->io, 8, 0, uart->name) < 0)
+		csr8o(ctlr, Scr, 0x55);
+		if(csr8r(ctlr, Scr) == 0x55)
+		if(ioalloc(ctlr->io, 8, 0, uart->name) >= 0)
 			continue;
 		if(uart == head)
 			head = uart->next;


### PR DESCRIPTION
https://9fans.topicbox.com/groups/9fans/T95b72661c697986e-M0444ff80cdfe937c6203393a/why-does-9legacys-9k-kernel-ignore-all-uarti8250-devices