### PR TITLE
sys/src/cmd/cc: fix special case for null pointer constants in cond expressions

### DIFF
--- a/sys/src/cmd/cc/cc.h
+++ b/sys/src/cmd/cc/cc.h
@@ -694,6 +694,7 @@ Type*	copytyp(Type*);
 void	typeext(Type*, Node*);
 void	typeext1(Type*, Node*);
 int	side(Node*);
+int	zpconst(Node*);
 int	vconst(Node*);
 int	log2(uvlong);
 int	vlog(Node*);

--- a/sys/src/cmd/cc/com.c
+++ b/sys/src/cmd/cc/com.c
@@ -331,11 +331,13 @@ tcomo(Node *n, int f)
 		o |= tcom(r->left);
 		if(o | tcom(r->right))
 			goto bad;
-		if(r->right->type->etype == TIND && vconst(r->left) == 0) {
+		if(r->right->type->etype == TIND && zpconst(r->left)) {
+			r->type = r->right->type;
 			r->left->type = r->right->type;
 			r->left->vconst = 0;
 		}
-		if(r->left->type->etype == TIND && vconst(r->right) == 0) {
+		if(r->left->type->etype == TIND && zpconst(r->right)) {
+			r->type = r->left->type;
 			r->right->type = r->left->type;
 			r->right->vconst = 0;
 		}

--- a/sys/src/cmd/cc/sub.c
+++ b/sys/src/cmd/cc/sub.c
@@ -988,6 +988,21 @@ loop:
 }
 
 int
+zpconst(Node *n)
+{
+	while(n->op == OCAST){
+		if(n->type == T)
+			break;
+		if(n->type->etype != TIND)
+			break;
+		if(n->type->link->etype != TVOID)
+			break;
+		n = n->left;
+	}
+	return vconst(n) == 0;
+}
+
+int
 vconst(Node *n)
 {
 	int i;


### PR DESCRIPTION
```c
c = expr ? a : b;
```

ref https://github.com/9front/9front/commit/3df95385bcc5294a212534d0991f1ffef1454aca