### PR TITLE
sys/src/9k: exec mkrootall and mkrr with rc explicitly

### DIFF
--- a/sys/src/9k/k10/mkfile
+++ b/sys/src/9k/k10/mkfile
@@ -89,7 +89,7 @@ sipi.h:		l64sipi.$O mkfile
 	 echo '};'} > $target
 
 $CONF.rr:	../mk/mkrr $CONF ./root/$CONF.proto
-	../mk/mkrr $CONF ./root/$CONF.proto
+	rc ../mk/mkrr $CONF ./root/$CONF.proto
 
 $CONF.rr:	./root/$O.cpu
 

--- a/sys/src/9k/mk/parse
+++ b/sys/src/9k/mk/parse
@@ -99,7 +99,7 @@ BEGIN{
 		s = ARGV[argc] ".root.s:D:";
 		for(i = 1; i < section["rootdir"]; i++)
 			s = s " " src[i];
-		s = s "\n\t../mk/mkrootall\\\n";
+		s = s "\n\trc ../mk/mkrootall\\\n";
 		for(i = 1; i < section["rootdir"]; i++)
 			s = s "\t\t" name[i] " " cname[i] " " src[i] "\\\n";
 		s = s "\t>$target\n";


### PR DESCRIPTION
I'm confusing

1. **9/port/mkrootall** has executable bit in its permission.
2. **9/port/mkbootrules** generates the script calling *mkrootall* without **rc**.
3. All files in **9k/mk/** does not have executable permission.
4. **9k/mk/parse** generates the script calling *mkrootall* without **rc** too.

Thus

* Add executable permission to *mkrootall*.
* Add explicit *rc* command.